### PR TITLE
Dm 51129

### DIFF
--- a/heliolinx/solarsyst_dyn_geo.py
+++ b/heliolinx/solarsyst_dyn_geo.py
@@ -270,10 +270,13 @@ def image_add_observerpos(image, obsarr, earthpos, **kwargs):
     
     b=np.empty((len(image),),dtype=hlimage) #new
     for i in range(len(image)) :
+        observatory=0
+        for j in range(len(obsarr)) :
+            if(image[i][3].decode('utf-8') == obsarr[j][0]) : observatory = obsarr[j]
         mjd = float(image[i][0])
-        Long = float(obsarr[0])
-        pcos = float(obsarr[1])
-        psin = float(obsarr[2])
+        Long = float(observatory[1])
+        pcos = float(observatory[2])
+        psin = float(observatory[3])
         obsx = hl.observer_vel(mjd,Long,pcos,psin,earthpos)
         a1 = 1
         b['MJD'][i] = image[i][0] #new
@@ -288,5 +291,6 @@ def image_add_observerpos(image, obsarr, earthpos, **kwargs):
         b['VZ'][i] = obsx[5]
         b['startind'][i]=0;
         b['endind'][i]=0;
+        b['exptime'][i] = image[i][12]
 
     return(b)

--- a/src/heliolinx.cpp
+++ b/src/heliolinx.cpp
@@ -300,6 +300,38 @@ std::tuple<py::array, py::array, py::array> makeTracklets(
   return(std::make_tuple(py_detout1, py_detout2, py_detout3));
 }
 
+// makeTrailedTracklets: May 27, 2025:
+// Minimalist wrapper, only handles the python <-> C++ translations.
+// All the interesting algorithmic stuff happens in functions called from solarsyst_dyn_geo01.
+
+std::tuple<py::array, py::array, py::array> makeTrailedTracklets(
+    MakeTrackletsConfig config,
+    py::array_t<hldet> py_detvec,
+    py::array_t<hlimage> py_imglog
+  ) {
+  cout << "C++ wrapper for make_trailed_tracklets, now fully functional\n";
+  
+  std::vector <hldet> detvec = ndarray_to_vec(py_detvec);
+  std::vector <hlimage> image_log = ndarray_to_vec(py_imglog);
+  std::vector <hldet> pairdets;
+  std::vector <tracklet> tracklets;
+  std::vector <longpair> trk2det;  
+
+  // Note: make_trailed_tracklets2 is an advance over make_trailed_tracklets
+  // in that it culls the ouput 'pairdets' array down to only those
+  // detections (sources) that were actually included in a tracklet.
+  make_trailed_tracklets2(detvec,image_log,config,pairdets,tracklets,trk2det);
+  
+  auto py_detout1 = vec_to_ndarray<hldet>(pairdets);
+  cout << "loaded pairdets\n";
+  auto py_detout2 = vec_to_ndarray<tracklet>(tracklets);
+  cout << "loaded tracklets\n";
+  auto py_detout3 = vec_to_ndarray<longpair>(trk2det);
+  cout << "loaded trk2det\n";
+
+  return(std::make_tuple(py_detout1, py_detout2, py_detout3));
+}
+
 // heliolinc: April 11, 2023:
 // Minimalist wrapper, only handles the python <-> C++ translations.
 // All the interesting algorithmic stuff happens in functions called from solarsyst_dyn_geo01.

--- a/src/make_tracklets.cpp
+++ b/src/make_tracklets.cpp
@@ -621,6 +621,17 @@ int main(int argc, char *argv[])
     outstream1.close();
   }
   
+  // Replace any invalid exposure times with the default (or user-supplied constant) value.
+  long exp_resetnum=0;
+  for(i=0;i<long(img_log.size());i++) {
+    if(img_log[i].exptime<=0.0l) {
+      cout << "Correcting exposure time on image " << i << ": " << img_log[i].MJD << " " << img_log[i].RA << " " << img_log[i].Dec << " " << img_log[i].obscode << ", exptime was " << img_log[i].exptime << "\n";
+      img_log[i].exptime = config.exptime;
+      exp_resetnum++;
+    }
+  }
+  cout << "In main, exposure time was corrected for " << exp_resetnum << " out of " << img_log.size() << " images\n";
+  
   // Write and print image log table
   cout << "Writing output image catalog " << outimfile << " with " << img_log.size() << " lines\n";
   outstream1.open(outimfile);
@@ -629,7 +640,7 @@ int main(int argc, char *argv[])
     outstream1 << fixed << setprecision(8) << " " << img_log[imct].Dec << " " << img_log[imct].obscode << " ";
     outstream1 << fixed << setprecision(1) << img_log[imct].X << " " << img_log[imct].Y << " " << img_log[imct].Z << " ";
     outstream1 << fixed << setprecision(4) << img_log[imct].VX << " " << img_log[imct].VY << " " << img_log[imct].VZ << " ";
-    outstream1 << img_log[imct].startind << " " << img_log[imct].endind << "\n";
+    outstream1 << img_log[imct].startind << " " << img_log[imct].endind << " " << img_log[imct].exptime << "\n";
   }
   outstream1.close();
 

--- a/src/make_trailed_tracklets.cpp
+++ b/src/make_trailed_tracklets.cpp
@@ -661,16 +661,6 @@ int main(int argc, char *argv[])
   if(DEBUGB==1) cout << "Preparing to load the image table\n";
   status = load_image_table(img_log, detvec, config.time_offset, observatory_list, EarthMJD, Earthpos, Earthvel);
   if(DEBUGB==1) cout << "Loaded the image table\n";
-  // Replace any invalid exposure times with the default (or user-supplied constant) value.
-  long exp_resetnum=0;
-  for(i=0;i<long(img_log.size());i++) {
-    if(img_log[i].exptime<=0.0l) {
-      cout << "Correcting exposure time on image " << i << ": " << img_log[i].MJD << " " << img_log[i].RA << " " << img_log[i].Dec << " " << img_log[i].obscode << ", exptime was " << img_log[i].exptime << "\n";
-      img_log[i].exptime = config.exptime;
-      exp_resetnum++;
-    }
-  }
-  cout << "Exposure time was corrected for " << exp_resetnum << " out of " << img_log.size() << " images\n";
 
   if(DEBUG>=2) {
     // Test: print out time-sorted detection table.
@@ -681,17 +671,27 @@ int main(int argc, char *argv[])
     outstream1.close();
   }
   
+  // Replace any invalid exposure times with the default (or user-supplied constant) value.
+  long exp_resetnum=0;
+  for(i=0;i<long(img_log.size());i++) {
+    if(img_log[i].exptime<=0.0l) {
+      cout << "Correcting exposure time on image " << i << ": " << img_log[i].MJD << " " << img_log[i].RA << " " << img_log[i].Dec << " " << img_log[i].obscode << ", exptime was " << img_log[i].exptime << "\n";
+      img_log[i].exptime = config.exptime;
+      exp_resetnum++;
+    }
+  }
+  cout << "In main, exposure time was corrected for " << exp_resetnum << " out of " << img_log.size() << " images\n";
+  
   // Write and print image log table
   cout << "Writing output image catalog " << outimfile << " with " << img_log.size() << " lines\n";
   outstream1.open(outimfile);
-  for(imct=0;imct<long(img_log.size());imct++)
-    {
-      outstream1 << fixed << setprecision(8) << img_log[imct].MJD << " " << img_log[imct].RA;
-      outstream1 << fixed << setprecision(8) << " " << img_log[imct].Dec << " " << img_log[imct].obscode << " ";
-      outstream1 << fixed << setprecision(1) << img_log[imct].X << " " << img_log[imct].Y << " " << img_log[imct].Z << " ";
-      outstream1 << fixed << setprecision(4) << img_log[imct].VX << " " << img_log[imct].VY << " " << img_log[imct].VZ << " ";
-      outstream1 << img_log[imct].startind << " " << img_log[imct].endind << "\n";
-    }
+  for(imct=0;imct<long(img_log.size());imct++) {
+    outstream1 << fixed << setprecision(8) << img_log[imct].MJD << " " << img_log[imct].RA;
+    outstream1 << fixed << setprecision(8) << " " << img_log[imct].Dec << " " << img_log[imct].obscode << " ";
+    outstream1 << fixed << setprecision(1) << img_log[imct].X << " " << img_log[imct].Y << " " << img_log[imct].Z << " ";
+    outstream1 << fixed << setprecision(4) << img_log[imct].VX << " " << img_log[imct].VY << " " << img_log[imct].VZ << " ";
+    outstream1 << img_log[imct].startind << " " << img_log[imct].endind << " " << img_log[imct].exptime << "\n";
+  }
   outstream1.close();
 
   make_trailed_tracklets2(detvec, img_log, config, pairdets, tracklets, trk2det);

--- a/src/solarsyst_dyn_geo01.cpp
+++ b/src/solarsyst_dyn_geo01.cpp
@@ -5950,6 +5950,7 @@ int observer_baryvel01(double detmjd, int polyorder, double lon, double obscos, 
   celestial_to_statevec(velRA,velDec,cvel,vel_from_geocen);
   // cvel is the Earth's rotation velocity at the latitude of
   // the observer, in km/sec.
+
   planetposvel01(detmjd,polyorder,earthpos,geocen_from_barycen,vel_from_barycen);
 
   outpos.x = geocen_from_barycen.x + obs_from_geocen.x;
@@ -23970,6 +23971,17 @@ int make_trailed_tracklets(vector <hldet> &detvec, vector <hlimage> &image_log, 
   }
   if(config.verbose) cout << "Verbose output has been requested\n";
   
+  // Replace any invalid exposure times with the default (or user-supplied constant) value.
+  long exp_resetnum=0;
+  for(i=0;i<long(image_log.size());i++) {
+    if(image_log[i].exptime<=0.0l) {
+      cout << "Correcting exposure time on image " << i << ": " << image_log[i].MJD << " " << image_log[i].RA << " " << image_log[i].Dec << " " << image_log[i].obscode << ", exptime was " << image_log[i].exptime << "\n";
+      image_log[i].exptime = config.exptime;
+      exp_resetnum++;
+    }
+  }
+  cout << "In make_trailed_tracklets(), exposure time was corrected for " << exp_resetnum << " out of " << image_log.size() << " images\n";
+  
   int status = load_image_indices(image_log, detvec, config.imagetimetol, config.forcerun);
   if(status!=0) {
     cerr << "ERROR: failed to load_image_indices from detection vector\n";
@@ -24038,19 +24050,35 @@ int make_trailed_tracklets2(vector <hldet> &detvec, vector <hlimage> &image_log,
   cout << "Minimum inter-image time interval: " << config.mintime << " days (" << config.mintime*1440.0 << " minutes)\n";
   cout << "Image radius: " << config.imagerad << " degrees\n";
   cout << "Maximum Great Circle Residual for tracklets with more than two points: " << config.maxgcr << " arcsec\n";
+  cout << "Exposure time: " << config.exptime << " seconds\n";
+  cout << "Scaling from trail length to its uncertainty: " << config.siglenscale << "\n";
+  cout << "Length used to estimate trail PA uncertainty: " << config.sigpascale << " arcsec\n";
+  cout << "Maximum non-exclusive tracklet length: " << config.max_netl << "\n";
+  cout << "Offset to be ADDED to observing times to get UTC: " << config.time_offset << " seconds\n";
   if(config.forcerun) {
     cout << "forcerun has been invoked: execution will attempt to push through\n";
     cout << "any errors that are not immediately fatal, including those that\n";
     cout << "could produce inaccurate final results.\n";
   }
   if(config.verbose) cout << "Verbose output has been requested\n";
-  
+
+  // Replace any invalid exposure times with the default (or user-supplied constant) value.
+  long exp_resetnum=0;
+  for(i=0;i<long(image_log.size());i++) {
+    if(image_log[i].exptime<=0.0l) {
+      cout << "Correcting exposure time on image " << i << ": " << image_log[i].MJD << " " << image_log[i].RA << " " << image_log[i].Dec << " " << image_log[i].obscode << ", exptime was " << image_log[i].exptime << "\n";
+      image_log[i].exptime = config.exptime;
+      exp_resetnum++;
+    }
+  }
+  cout << "In make_trailed_tracklets2(), exposure time was corrected for " << exp_resetnum << " out of " << image_log.size() << " images\n";
+
   int status = load_image_indices(image_log, detvec, config.imagetimetol, config.forcerun);
   if(status!=0) {
     cerr << "ERROR: failed to load_image_indices from detection vector\n";
     return(status);
   }
-  
+
   // Echo detection vector
   //for(i=0;i<detvec.size();i++) {
   //  cout << "det " << i << " " << detvec[i].MJD << " " << detvec[i].RA << " " << detvec[i].Dec << " " << detvec[i].mag  << " " << detvec[i].obscode << " " << detvec[i].image << "\n";


### PR DESCRIPTION
I have edited the file heliolinx.cpp to add a python-wrapping for the C++ routine make_trailed_tracklets2(), which is found in solarsyst_dyn_geo01.cpp. I also made some edits to the function image_add_observerpos() in solarsyst_dyn_geo.py, which reverted an earlier change to the observatory code lookup function. I had reviewed and accepted this change earlier, but that turns out to have been a mistake: it breaks the function, and I had to revert it to obtain a successful test of the new python-wrapper for make_trailed_tracklets.